### PR TITLE
Fix the path for copying the php.ini file in Docker base template v2

### DIFF
--- a/dist/Docker/nginx/nginx.conf
+++ b/dist/Docker/nginx/nginx.conf
@@ -41,5 +41,8 @@ server {
         expires -1;
         log_not_found off;
     }
+
+    # Sets the maximum allowed size of the client request body
+    client_max_body_size 64M;
  
 }

--- a/dist/Docker/php/php.ini
+++ b/dist/Docker/php/php.ini
@@ -119,6 +119,5 @@ mbstring.language = neutral
 mbstring.internal_encoding = UTF-8
 mbstring.http_input = auto
 mbstring.http_output = UTF-8
-mbstring.encoding_translation = Off
 mbstring.detect_order = auto
 mbstring.substitute_character = none

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -78,8 +78,7 @@ RUN chown -R www-data:www-data /app \
 RUN COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction --no-dev --optimize-autoloader --prefer-dist --no-scripts
 
 # Copy PHP configuration files
-COPY ./Docker/php/php.ini /etc/php/8.3/fpm/php.ini
-COPY ./Docker/php/php.ini /etc/php/8.3/cli/php.ini
+COPY ./Docker/php/php.ini /usr/local/etc/php/conf.d/php.ini
 
 # SSH setup
 RUN echo "root:Docker!" | chpasswd \


### PR DESCRIPTION
Fix in Docker base template v2
- Removed mbstring.encoding_translation: Off; from php.ini due to facing an error message, indicates that the multibyte string input conversion is enabled. 
        - By default, mbstring.encoding_translation is Off
- The path for copying the php.ini file
- Added client request body on nginx.conf file.